### PR TITLE
fix: certification request routing

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -1,4 +1,7 @@
 {
   "directoryListing": false,
-  "trailingSlash": false
+  "trailingSlash": false,
+  "rewrites": [
+    { "source": "/certification/**", "destination": "/certification/index.html" }
+  ]
 }


### PR DESCRIPTION
Certification urls are of the form `certification/developmentuser/responsive-web-design`, but they are client-only routes, so there is only one `index.html` file inside `certification`.  This change ensures that that file is served for all requests.